### PR TITLE
Include mex.h to avoid mxArray type unknown error

### DIFF
--- a/CERR_core/MeshBasedInterp/MeshContour.h
+++ b/CERR_core/MeshBasedInterp/MeshContour.h
@@ -2,6 +2,7 @@
 #define MeshContour_h
 
 /* This is from shrhelp.h */
+#include "mex.h"
 #ifndef SHRHELP
 #define SHRHELP
 


### PR DESCRIPTION
Include mex.h to avoid mxArray type unknown error