### PR TITLE
Fix bug where PET scans aren't imported or exported properly

### DIFF
--- a/ML_Dicom/Export/modules/export_PT_image_module_field.m
+++ b/ML_Dicom/Export/modules/export_PT_image_module_field.m
@@ -55,33 +55,27 @@ switch tag
     %Class 1 Tags -- Required, must have data.
     case 524296     %0008,0008 Image Type
         data = {'ORIGINAL', 'PRIMARY', 'AXIAL'};
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2621442    %0028,0002 Samples per Pixel
         data = 1;               %1 image plane in all CT/MR images.
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2621444    %0028,0004 Photometric Interpretation
         data = 'MONOCHROME2';   %CT/MR have 0 black, maxVal white.
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2621456    %0028,0010 Rows
         data = scanInfoS.sizeOfDimension1;
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2621457    %0028,0011 Columns
         data = scanInfoS.sizeOfDimension2;
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2621696    %0028,0100 Bits Allocated
         data = 16;              %C.8.2.1.1.4 of PS 3.3 - 2006
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2621697    %0028,0101 Bits Stored
         %C.8.2.1.1.4 of PS 3.3 - 2006
@@ -106,8 +100,7 @@ switch tag
         mostSignificantBit = floor(max(log2s)) + 1;
         data = max(mostSignificantBit, 12);
         data = min(data, 16);
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2621698    %0028,0102 High Bit
         %C.8.2.1.1.4 of PS 3.3 - 2006
@@ -134,15 +127,13 @@ switch tag
         data = max(mostSignificantBit, 12);
         data = min(data, 16);
         data = data - 1;
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
         
     case 2625618    %0028,1052 Rescale Intercept
         ctO = scanInfoS.CTOffset;
         data = -ctO;           %CERR exports stored values as 1*HU + CTOffset.
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 2625619    %0028,1053 Rescale Slope
         %data = 1;
@@ -150,40 +141,26 @@ switch tag
         data = args.data{3}; %APA: factor for conversion to uint16 for modalities other than CT
         bools = [scanS.scanInfo.zValue] == scanInfoS.zValue;
         data = data(bools);
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 1052720    %0010,1030 Patient Weight
         data = scanInfoS.DICOMHeaders.PatientWeight;
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 524338     %0008,0032 Acquisition Time
         data = scanInfoS.DICOMHeaders.AcquisitionTime;
-        el = template.get(tag);
-        el = ml2dcm_Element(el, data);
+        el = data2dcmElement(template, data, tag);
         
     case 5505046    %0054,0016 Radiopharmaceutical Information Sequence
-        templateEl  = template.get(tag);
-        fHandle = @export_radiopharmaceutical_info_sequence;
-        
-        tmp = org.dcm4che2.data.BasicDicomObject;
-        el = tmp.putNull(tag, []);
-        
-        nItems = 1;
-        
-        for i=1:nItems
-            dcmobj = export_sequence(fHandle, templateEl, {scanInfoS});
-            el.addDicomObject(i-1, dcmobj);
-        end
-        
+        data = scanInfoS.DICOMHeaders.RadiopharmaceuticalInformationSequence.Item_1;
+        el = data2dcmElement(template,data,tag);
         
         %Class 2 Tags -- Must be present, can be NULL.
     case 1572960    %0018,0060 KVP
-        el = template.get(tag);
+        el = data2dcmElement(template, 0.0, tag);
         
     case 2097170    %0020,0012 Acqusition Number
-        el = template.get(tag);
+        el = data2dcmElement(template, 0, tag);
         
         %Class 3 Tags -- presence is optional, currently undefined.
     case 1572898    %0018,0022 Scan Options

--- a/ML_Dicom/util/data2dcmElement.m
+++ b/ML_Dicom/util/data2dcmElement.m
@@ -31,7 +31,7 @@ function el = data2dcmElement(el, data, tag)
 % You should have received a copy of the GNU General Public License
 % along with CERR.  If not, see <http://www.gnu.org/licenses/>.
 
-%Create an empty attr to act as a temporary container for the new element.
+%Create an isempty attr to act as a temporary container for the new element.
 attr = org.dcm4che3.data.Attributes;
 vr = org.dcm4che3.data.ElementDictionary.vrOf(tag, []);
 vrString = char(vr);
@@ -142,7 +142,105 @@ switch upper(vrString)
         %Needs implementation       
         attr.setInt(tag, vr, data);
     case 'SQ'
-        %Implementation currently unnecessary.
+        
+         fN = fieldnames(data);
+         sz = size(fN,1);
+        
+         seq = attr.newSequence(tag, sz);
+  
+         %RADIOPHARMA INFO SEQ
+         if tag == 5505046
+             
+             %RADIOPHARACEUTICAL
+             el = data2dcmElement(el,data.Radiopharmaceutical,1572913);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             %RADIO VOLUME
+             el = data2dcmElement(el,data.RadiopharmaceuticalVolume,1577073);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             %RADIO START TIME
+             el = data2dcmElement(el,data.RadiopharmaceuticalStartTime,1577074);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+           
+             %RADIO STOP TIME
+             el = data2dcmElement(el,data.RadiopharmaceuticalStopTime,1577075);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             %RADIO TOTAL DOSE
+             el = data2dcmElement(el,data.RadionuclideTotalDose,1577076);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             
+             %RADIO HALF LIFE
+             el = data2dcmElement(el,data.RadionuclideHalfLife,1577077);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             
+             %RADIO POS FRAC
+             el = data2dcmElement(el,data.RadionuclidePositronFraction,1577078);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             %RADIOPHARMA START DATE TIME
+             el = data2dcmElement(el,data.RadiopharmaceuticalStartDateTime,1577080);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+            
+             %RADIOPHARMA STOP DATE TIME
+             el = data2dcmElement(el,data.RadiopharmaceuticalStopDateTime,1577081);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             %RADIONUCLIDE CODE SEQ
+             el = data2dcmElement(el,data.RadionuclideCodeSequence.Item_1,5505792);  
+             if ~isempty(el)
+                 seq.add(el);
+             end
+             
+             %RADIONUCLIDE CODE SEQ
+             el = data2dcmElement(el,data.RadiopharmaceuticalCodeSequence.Item_1,5505796);
+             if ~isempty(el)
+                 seq.add(el);
+             end
+         elseif tag == 5505792 || 5505796
+            %code value = 0008 0100 VR = SH
+            el = data2dcmElement(el,data.CodeValue,524544);
+            if ~isempty(el)
+                seq.add(el);
+            end
+            
+            %coding scheme designator 0008 0102 VR = SH
+            el = data2dcmElement(el,data.CodingSchemeDesignator,524546);
+            if ~isempty(el)
+                seq.add(el);
+            end
+            
+            %code meaning 0008 0104 VR = LO
+            el = data2dcmElement(el,data.CodeMeaning,524548);
+            if ~isempty(el)
+                seq.add(el);
+            end
+            
+         end
+         
+         attr.setValue(tag,vr,seq);
+        
     case 'SS'
         %Needs implementation
     case 'TM'   
@@ -168,7 +266,7 @@ switch upper(vrString)
 end
 
 %DEBUGGING CODE: remove this once all VRs are implemented.
-if attr.isEmpty
+if attr.isempty
     warning(['DEBUGGING: ' vrString ' is not defined.  Implement it in data2dcmElement.m']);
     el = [];
 

--- a/ML_Dicom/util/getTagValue.m
+++ b/ML_Dicom/util/getTagValue.m
@@ -134,7 +134,11 @@ switch upper(vr)
         end
         data = [];
         for i=0:nElements-1
-            data.(['Item_' num2str(i+1)]) = getTagStruct(el.get(i)); %CHANGE THIS TOO IMPORTANT
+            a = getTagStruct(el.get(i)); %CHANGE THIS TOO IMPORTANT
+            if ~isempty(a)
+                b =  char(fieldnames(a));
+                data.('Item_1').(b) = a.(b); %CHANGE THIS TOO IMPORTANT
+            end
         end
     case 'SS'
         %Needs implementation


### PR DESCRIPTION
This fixes issue, where radiopharma information is not exported or imported correctly in to planC. This fix is critical for PET imaging. [#368](https://github.com/cerr/CERR/issues/368).