### PR TITLE
Updates

### DIFF
--- a/CERR_core/DLSegmentationTraining/CERRtoHDF5.m
+++ b/CERR_core/DLSegmentationTraining/CERRtoHDF5.m
@@ -35,7 +35,7 @@ else
     strListC = {};
     labelKeyS = [];
 end
-skipMaskExport = false;
+skipMaskExport = true;
 
 %% Get data split
 [trainIdxV,valIdxV,testIdxV] = randSplitData(CERRdir,dataSplitV);

--- a/CERR_core/ModelImplementationLibrary/SegmentationModels/ModelConfigurations/CBCT_LungTumor_CMEDL_config.json
+++ b/CERR_core/ModelImplementationLibrary/SegmentationModels/ModelConfigurations/CBCT_LungTumor_CMEDL_config.json
@@ -1,0 +1,31 @@
+{
+
+ "strNameToLabelMap": {
+       "structureName": "Tumor",
+       "value": 1
+       },
+
+"scan":{
+
+        "identifier" : {"imageType": "CBCT SCAN"},
+
+        "crop": {"method": "crop_to_str",
+                 "params" : {"structureName": "Lung"},
+                 "operator" : ""},
+
+        "resize":{
+                    "preserveAspectRatio": "Yes",
+                    "method" : "bicubic",
+                    "size" : [256,256]
+                 }
+ },
+
+
+"passedScanDim" : "3D",
+
+"batchSize": 1,
+
+"structAssocScan": {"identifier": {"imageType":"CBCT SCAN"}}
+
+
+}

--- a/CERR_core/PlanMetrics/heterogenity_metrics/generateTextureMapFromPlanC.m
+++ b/CERR_core/PlanMetrics/heterogenity_metrics/generateTextureMapFromPlanC.m
@@ -57,11 +57,15 @@ for n = 1:length(fieldNamesC)
     %Remove padding
     if filtParamS.padding.flag
        padSizV = filtParamS.padding.size;
-       filtScan3M = filtScan3M(padSizV(1)+1 : texSizV(1)-padSizV(1),...
-           padSizV(2)+1 : texSizV(2)-padSizV(2),...
-           padSizV(3)+1 : texSizV(3)-padSizV(3));
+    else
+        %Undo default padding
+        padSizV = [5,5,5];
     end
-    
+    filtScan3M = filtScan3M(padSizV(1)+1 : texSizV(1)-padSizV(1),...
+        padSizV(2)+1 : texSizV(2)-padSizV(2),...
+        padSizV(3)+1 : texSizV(3)-padSizV(3));
+    [~, maxr, minc, ~] = compute_boundingbox(mask3M);
+
     %Create texture object
     assocScanUID = planC{indexS.scan}(scanNum).scanUID;
     nTexture = length(planC{indexS.texture}) + 1;


### PR DESCRIPTION
1) Undo default padding
2) Skip mask export by default
3) Preprocessing config for lung tumor segmentation model